### PR TITLE
Improve existing playback controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <!--Audio element-->
 <audio id="audio" preload="none"></audio>
 
-<body>
+<body onkeyup="keypress()">
   <!--Colorful border-->
   <div id="colored">
     <!--Inner solid-color area-->
@@ -25,7 +25,7 @@
           <h2 id="description"></h2>
         </div>
         <!--Progress bar-->
-        <input type="range" id="progress" min="0" max="" onmousedown="preventUpdate()" onchange="skip()" />
+        <input type="range" id="progress" min="0" max="" oninput="preventUpdate()" onchange="skip()">
       </div>
       <!--Episode artwork-->
       <img id="artwork" alt="Episode artwork" />

--- a/mainstyle.css
+++ b/mainstyle.css
@@ -81,8 +81,8 @@ body {
 #playback {
   width: 100%;
   margin: auto;
-  margin-left: .5em;
-  margin-right: .75em;
+  margin-left: 7px;
+  margin-right: 20px;
 }
 
 #info {

--- a/mainstyle.css
+++ b/mainstyle.css
@@ -55,30 +55,38 @@ body {
 
 #inner {
   height: 100%;
+  box-sizing: border-box;
   display: flex;
+  justify-content: space-around;
   background: #ffffff;
   border-radius: 7px;
 }
 
 #playPause {
-  height: 100%;
-  max-width: 10%;
+  max-width: 50vh;
+  min-width: 2em;
+  width: 20%;
   margin: auto;
-  margin-right: 0.5em;
   padding: 0;
 }
 
 #playPause:hover {
-  filter: opacity(60%);
+  opacity: 60%;
+}
+
+#playPause:hover:active {
+  opacity: 20%;
 }
 
 #playback {
   width: 100%;
   margin: auto;
+  margin-left: .5em;
+  margin-right: .75em;
 }
 
 #info {
-  margin-top: -1.5em;
+  margin-top: -1.75em;
   margin-bottom: 0.25em;
   transition-duration: 500ms;
   opacity: 0;
@@ -95,6 +103,5 @@ body {
   max-height: 100%;
   max-width: 15%;
   margin: auto;
-  margin-left: 0.5em;
-  margin-right: 0;
+  margin-right: 5px;
 }

--- a/script.js
+++ b/script.js
@@ -24,8 +24,6 @@ progressBar.max = episode.duration;
 progressBar.value = 0;
 var border = getElem("colored");
 var playing = false;
-var interval;
-var updateInterval = 500; //Interval between progress bar updates
 
 //End of episode resets controls
 audio.addEventListener("ended", function () {
@@ -64,7 +62,7 @@ function play() {
   audio.play();
   getElem("playPause").src = "assets/pause.svg";
   getElem("playPause").alt = "Pause";
-  interval = setInterval(updateProgress, updateInterval);
+  audio.addEventListener("timeupdate", updateProgress);
   displayInfo();
   border.style.animationPlayState = "running";
 }
@@ -76,7 +74,7 @@ function pause() {
   audio.pause();
   getElem("playPause").src = "assets/play.svg";
   getElem("playPause").alt = "Play";
-  clearInterval(interval);
+  audio.removeEventListener("timeupdate", updateProgress)
   border.style.animationPlayState = "paused";
 }
 
@@ -85,12 +83,19 @@ function skip() {
   "use strict";
   audio.currentTime = progressBar.value;
   if (playing) {
-    interval = setInterval(updateProgress, updateInterval);
+    audio.addEventListener("timeupdate", updateProgress);
   }
 }
 
 //Stop updating progress bar
 function preventUpdate() {
   "use strict";
-  clearInterval(interval);
+  audio.removeEventListener("timeupdate", updateProgress);
+}
+
+//Process keyboard events
+function keypress() {
+  if (event.code == "Space") {
+    playPause();
+  };
 }


### PR DESCRIPTION
**Issue**
Fixes #3 

**Description**
Add ability to play/pause using spacebar while body is focused by evaluating all keyups while body is focused. This function can be used to add future keyboard functionality.
Change preventUpdate function to start oninput instead of onmousedown.
Resize playPause element to better fit body size.
Add active pseudoclass to playPause element to provide a visual indication of click/tap.
Change initial offset of info section to better center the progress bar vertically.
Change calls to updateProgress function to update on timeupdate rather than setInterval.

**Potential Points of Failure**
Spacing of elements for some pages could have changed for some body sizes.
Keyboard actions on other parts of pages with player embedded could erroneously interact with player.

**Branching Recommendation**
N/A